### PR TITLE
Add support of using alternative disk names

### DIFF
--- a/lockpi.sh
+++ b/lockpi.sh
@@ -202,18 +202,24 @@ detect_version(){
 USE_LUKS=1;
 LUKS_MAPPER="crypt_pi";
 format(){
-	# detect if device is SD/MMC
-	if [ -z "$(printf ${TARGET_BLOCK_DEVICE} |grep mmcblk)" ]; then {
-		BOOTPART="${TARGET_BLOCK_DEVICE}1";
-		ROOTPART="${TARGET_BLOCK_DEVICE}2";
-	} ;
-	else {
-		blkdiscard -f "${TARGET_BLOCK_DEVICE}";
-		BOOTPART="${TARGET_BLOCK_DEVICE}p1";
-		ROOTPART="${TARGET_BLOCK_DEVICE}p2";
-	} 
-	fi;
-	
+	# detect device name scheme
+	case "${TARGET_BLOCK_DEVICE}" in
+		/dev/disk/*)
+			BOOTPART="${TARGET_BLOCK_DEVICE}-part1";
+			ROOTPART="${TARGET_BLOCK_DEVICE}-part2";
+			;;
+		/dev/sd[a-z])
+			BOOTPART="${TARGET_BLOCK_DEVICE}1";
+			ROOTPART="${TARGET_BLOCK_DEVICE}2";
+			;;
+		*)
+			BOOTPART="${TARGET_BLOCK_DEVICE}p1";
+			ROOTPART="${TARGET_BLOCK_DEVICE}p2";
+			;;
+	esac
+
+	blkdiscard -f "${TARGET_BLOCK_DEVICE}";
+
 	# create partitions
 	#echo -e "o\np\nn\np\n1\n\n+200M\nt\nc\nn\np\n2\n\n\nw\n" | fdisk "${TARGET_BLOCK_DEVICE}";
 	printf "o\np\nn\np\n1\n\n+200M\nt\nc\nn\np\n2\n\n\nw\n\n" | fdisk "${TARGET_BLOCK_DEVICE}";
@@ -602,18 +608,23 @@ test_func(){
 	
 	printf "%s" "${CHROOT_SCRIPT_RASPIOS}" > /tmp/chroot_test.sh
 	
-	local TARGET_BLOCK_DEVICE=/dev/mmcblk1
-	# detect if device is SD/MMC
-	if [ -z "$(printf ${TARGET_BLOCK_DEVICE} |grep mmcblk)" ]; then {
-		BOOTPART="${TARGET_BLOCK_DEVICE}1";
-		ROOTPART="${TARGET_BLOCK_DEVICE}2";
-	} ;
-	else {
-		#blkdiscard -f "${TARGET_BLOCK_DEVICE}";
-		BOOTPART="${TARGET_BLOCK_DEVICE}p1";
-		ROOTPART="${TARGET_BLOCK_DEVICE}p2";
-	} 
-	fi;
+	#local TARGET_BLOCK_DEVICE=/dev/mmcblk1
+	local TARGET_BLOCK_DEVICE=/dev/disk/by-path/pci-0000:00:1a.0-usb-0:1.4:1.0-scsi-0:0:0:0
+	# detect device name scheme
+	case "${TARGET_BLOCK_DEVICE}" in
+		/dev/disk/*)
+			BOOTPART="${TARGET_BLOCK_DEVICE}-part1";
+			ROOTPART="${TARGET_BLOCK_DEVICE}-part2";
+			;;
+		/dev/sd[a-z])
+			BOOTPART="${TARGET_BLOCK_DEVICE}1";
+			ROOTPART="${TARGET_BLOCK_DEVICE}2";
+			;;
+		*)
+			BOOTPART="${TARGET_BLOCK_DEVICE}p1";
+			ROOTPART="${TARGET_BLOCK_DEVICE}p2";
+			;;
+	esac
 	printf "BOOTPART: %s\nROOTPART: %s\n" "${BOOTPART}" "${ROOTPART}";
 	
 	exit 0;


### PR DESCRIPTION
This pull-request adds the support for alternative disk names under `/dev/disk/` directory.

Using those alternative name has many advantages, since it providing more reliable ways to identify disks. 

For example:
```
$ ls -l /dev/disk/by-path/
total 0
lrwxrwxrwx 1 root root  9 May  4 18:32 pci-0000:00:1a.0-usb-0:1.4:1.0-scsi-0:0:0:0 -> ../../sdd
lrwxrwxrwx 1 root root 10 May  4 18:32 pci-0000:00:1a.0-usb-0:1.4:1.0-scsi-0:0:0:0-part1 -> ../../sdd1
lrwxrwxrwx 1 root root 10 May  4 18:32 pci-0000:00:1a.0-usb-0:1.4:1.0-scsi-0:0:0:0-part2 -> ../../sdd2
lrwxrwxrwx 1 root root  9 Feb  8 21:28 pci-0000:02:00.0-scsi-0:0:12:0 -> ../../sdb
lrwxrwxrwx 1 root root 10 Feb  8 21:28 pci-0000:02:00.0-scsi-0:0:12:0-part1 -> ../../sdb1
lrwxrwxrwx 1 root root 10 Feb  8 21:28 pci-0000:02:00.0-scsi-0:0:12:0-part2 -> ../../sdb2
lrwxrwxrwx 1 root root  9 Feb  8 21:28 pci-0000:02:00.0-scsi-0:0:13:0 -> ../../sdc
lrwxrwxrwx 1 root root 10 Feb  8 21:28 pci-0000:02:00.0-scsi-0:0:13:0-part1 -> ../../sdc1
lrwxrwxrwx 1 root root 10 Feb  8 21:28 pci-0000:02:00.0-scsi-0:0:13:0-part2 -> ../../sdc2
lrwxrwxrwx 1 root root  9 May  4 17:56 pci-0000:02:00.0-scsi-0:0:7:0 -> ../../sda
lrwxrwxrwx 1 root root 10 May  4 17:56 pci-0000:02:00.0-scsi-0:0:7:0-part1 -> ../../sda1
lrwxrwxrwx 1 root root 10 May  4 17:56 pci-0000:02:00.0-scsi-0:0:7:0-part2 -> ../../sda2
lrwxrwxrwx 1 root root 10 May  4 17:56 pci-0000:02:00.0-scsi-0:0:7:0-part3 -> ../../sda3
```
by using these names under `by-path`, an user could immediately identify the newly plugged USB disk (which has the base name `sdd`), without worrying about overwriting the wrong disk.